### PR TITLE
Fix console errors for Issue126

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,12 +8,12 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "icon192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "icon512.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/src/components/LoadingWheel/LoadingWheel.component.js
+++ b/src/components/LoadingWheel/LoadingWheel.component.js
@@ -19,7 +19,7 @@ export const LoadingWheel = ({ overlay }) => {
             : "loading-wheel-inner-container-white"
         }
       >
-        <div class="lds-ring">
+        <div className="lds-ring">
           <div></div>
           <div></div>
           <div></div>

--- a/src/components/VoterRegistration/VoterRegistrationForm.js
+++ b/src/components/VoterRegistration/VoterRegistrationForm.js
@@ -16,7 +16,7 @@ const db = getFirestore();
 
 export default function VoterRegistrationForm(props) {
   const { currentUser } = useAuth();
-  const [loading, setLoading] = useState(false);
+  //const [loading, setLoading] = useState(false);
 
   //if the user has already completed the register to vote action, set the page to "formCompleted"
   const [page, setPage] = useState("loading");
@@ -25,9 +25,9 @@ export default function VoterRegistrationForm(props) {
     setTimeout(() => {
       if (localStorage.getItem("player") && currentUser) {
         addInvitedBy();
-        setLoading(true);
+       // setLoading(true);
       } else {
-        setLoading(true);
+        //setLoading(true);
       }
       (async () => {
         const userRef = doc(db, "users", currentUser.uid);
@@ -82,8 +82,8 @@ export default function VoterRegistrationForm(props) {
     race: "asian",
   });
 
-  return loading ? (
-    <form className={page !== "loading" && "container"}>
+  return page !== "loading" ? (
+    <form className={page !== "loading" ? "container" : null}>
       {page !== "loading" && (
         <h1 className="register-form-title">
           {page !== "formCompleted" ? (


### PR DESCRIPTION
## Overview 
> The following were done to fix console errors on the voter registration page.
1. Change class to className in loadingwheel.js
2. Change conditional className assignment of `<form>` in voterregistrationform.js
3. Replace state hook `loading` and use state hook `page` to remove redundancy of states.

>The following were done to fix an additional console error:
1. Change logo192.png and logo512.png to iconXXX.png in manifest to match image file names in public folder.


## Test Plan 
> 1. After making changes verified loading wheel still shows when `page` state is "loading" and transitions to show `<form>` once loaded.
2. Verify className of `<form>` is changing with the state of `page`
3.  Followed voter registration process to ensure nothing broke.


## Follow-ups 
> Remove state hook `loading` in future (currently commented out)

