### PR TITLE
change margin of Election Alerts page

### DIFF
--- a/src/components/ElectionReminders/ElectionReminder.scss
+++ b/src/components/ElectionReminders/ElectionReminder.scss
@@ -82,6 +82,11 @@
     color: black;
   }
 
+  #NVSignupForm61312-ContactInformation-SmsLegalDisclaimer a {
+    color: black;
+    text-decoration: underline;
+  }
+
   .btn-at-primary {
     @include button;
   }

--- a/src/components/ElectionReminders/ElectionReminder.scss
+++ b/src/components/ElectionReminders/ElectionReminder.scss
@@ -53,7 +53,7 @@
   .reminders-completed {
     font-family: "Lato", sans-serif;
     color: black;
-    margin-left: 20px;
+    margin: 0px 30px;
   }
 
   .reminders-completed h3 {

--- a/src/components/ElectionReminders/ElectionReminder.scss
+++ b/src/components/ElectionReminders/ElectionReminder.scss
@@ -9,11 +9,12 @@
   }
 
   .title {
-    padding: 0 30px;
     margin-top: 24px;
+    margin-left: 30px;
+    margin-right: 30px;
     @include heading-text;
     text-align: left !important;
-    width: 100%;
+    width: calc(100% - 60px);
     // float: left !important;
   }
 
@@ -24,7 +25,6 @@
   .at-form-submit {
     display: flex;
     justify-content: center;
-    margin: 0 10px;
   }
 
   .ngp-form label {
@@ -40,19 +40,15 @@
   }
 
   .ngp-form {
-    width: 100%;
+    width: calc(100% - 20px);
+    margin: 0 10px;
   }
 
   .at-legend {
     font-family: "Lato", sans-serif !important;
-    padding-right: 10px !important;
-    padding-left: 10px !important;
+    width: auto;
   }
 
-  .at-fields {
-    padding-right: 10px !important;
-    padding-left: 10px !important;
-  }
 
   .reminders-completed {
     font-family: "Lato", sans-serif;
@@ -92,7 +88,7 @@
 
   .contributions h1 {
     width: 100%;
-    margin-left: 10px;
+    margin-left: 0 !important;
     margin-top: 40px;
     font-family: $bebas-neue !important;
     font-size: 24px !important;
@@ -102,7 +98,7 @@
   .contributions p {
     width: 100%;
     margin-top: 40px;
-    margin-left: 10px;
+    margin-left: 0 !important;
   }
 
   #continue {

--- a/src/components/ElectionReminders/ElectionReminder.scss
+++ b/src/components/ElectionReminders/ElectionReminder.scss
@@ -9,7 +9,7 @@
   }
 
   .title {
-    margin-left: 20px;
+    padding: 0 30px;
     margin-top: 24px;
     @include heading-text;
     text-align: left !important;
@@ -24,6 +24,7 @@
   .at-form-submit {
     display: flex;
     justify-content: center;
+    margin: 0 10px;
   }
 
   .ngp-form label {
@@ -38,9 +39,19 @@
     display: none;
   }
 
+  .ngp-form {
+    width: 100%;
+  }
+
   .at-legend {
     font-family: "Lato", sans-serif !important;
-    padding-right: 18px !important;
+    padding-right: 10px !important;
+    padding-left: 10px !important;
+  }
+
+  .at-fields {
+    padding-right: 10px !important;
+    padding-left: 10px !important;
   }
 
   .reminders-completed {
@@ -66,6 +77,7 @@
   }
   .thankYou {
     background-color: white !important;
+    padding: 0 20px;
   }
 
   #NVSignupForm61312-ContactInformation-SmsLegalDisclaimer {
@@ -95,7 +107,7 @@
 
   #continue {
     @include button;
-    margin-top: 40px;
-    margin-bottom: 40px;
+    width: auto !important;
+    margin: 40px 30px !important;
   }
 }


### PR DESCRIPTION
## Overview 
35. Get Election Alerts form: Increase margins to 30px. 
36. Change link styles to bold and underline, in black.


## Test Plan 
Go to /election-reminders and inspect elements to make sure they align correctly.





## Follow ups 
> It is okay for the PR to be not perfect, list what you/other should work on after this PR is merged

